### PR TITLE
fix(post): 編輯成功後刷新原頁並定位原樓層

### DIFF
--- a/lib/features/post/view/post_edit_page.dart
+++ b/lib/features/post/view/post_edit_page.dart
@@ -775,7 +775,7 @@ class _PostEditPageState extends State<PostEditPage> with LoggerMixin {
       if (widget.editType.isEditingPost) {
         // Edit post.
         showSnackBar(context: context, message: context.t.postEditPage.editSuccess);
-        context.pop();
+        context.pop(true);
         return;
       } else if (widget.editType.isEditingDraft) {
         // Writing new post.

--- a/lib/features/thread/v1/view/thread_page.dart
+++ b/lib/features/thread/v1/view/thread_page.dart
@@ -134,7 +134,7 @@ class _ThreadPageState extends State<ThreadPage> with SingleTickerProviderStateM
 
   final _replyBarController = ReplyBarController();
 
-  /// Floor to scroll to when the thread reloads after a reply: the post the user just wrote. Read by the next
+  /// Floor to scroll to when the thread reloads after a reply or edit. Read by the next
   /// [PostList] in its `initState` and forgotten right after, so later reloads do not jump back to it.
   String? _scrollToPidOnReload;
 
@@ -263,7 +263,11 @@ class _ThreadPageState extends State<ThreadPage> with SingleTickerProviderStateM
             pageNumber: context.read<JumpPageCubit>().state.currentPage,
             initialPostID: (_scrollToPidOnReload ?? widget.findPostID)?.parseToInt(),
             scrollController: _listScrollController,
-            widgetBuilder: (context, post) => PostCard(post, replyCallback: replyPostCallback),
+            widgetBuilder: (context, post) => PostCard(
+              post,
+              replyCallback: replyPostCallback,
+              onEdited: () => _scrollToPidOnReload = post.postID,
+            ),
             useDivider: true,
             postList: state.postList,
             canLoadMore: state.canLoadMore,

--- a/lib/widgets/card/post_card/post_card.dart
+++ b/lib/widgets/card/post_card/post_card.dart
@@ -72,7 +72,7 @@ enum _PostCardActions {
 /// Usually inside a ThreadPage.
 class PostCard extends StatefulWidget {
   /// Constructor.
-  const PostCard(this.post, {this.replyCallback, super.key});
+  const PostCard(this.post, {this.replyCallback, this.onEdited, super.key});
 
   /// [Post] model to show.
   final Post post;
@@ -80,6 +80,9 @@ class PostCard extends StatefulWidget {
   /// A callback function that will be called every time when user try to
   /// reply to the post.
   final FutureOr<void> Function(User user, int? postFloor, String? replyAction)? replyCallback;
+
+  /// Called after a successful edit, before reloading, so the thread can retain this floor as its scroll target.
+  final VoidCallback? onEdited;
 
   @override
   State<PostCard> createState() => _PostCardState();
@@ -408,11 +411,16 @@ class _PostCardState extends State<PostCard> with AutomaticKeepAliveClientMixin 
       case _PostCardActions.edit:
         final url = Uri.parse(widget.post.editUrl!);
         final editType = widget.post.isDraft ? PostEditType.editDraft.index : PostEditType.editPost.index;
-        await context.pushNamed(
+        final edited = await context.pushNamed<bool>(
           ScreenPaths.editPost,
           pathParameters: {'editType': '$editType', 'fid': '${url.queryParameters["fid"]}'},
           queryParameters: {'tid': '${url.queryParameters["tid"]}', 'pid': '${url.queryParameters["pid"]}'},
         );
+        if ((edited ?? false) && context.mounted) {
+          widget.onEdited?.call();
+          // A list may contain several loaded pages. Reload the edited post's page, not the last loaded page or 1.
+          context.read<ThreadBloc>().add(ThreadJumpPageRequested(widget.post.page));
+        }
       case _PostCardActions.share:
         await copyToClipboard(context, widget.post.shareLink!);
       case _PostCardActions.openInBrowser:

--- a/test/regression/test_067_edit_post_refresh_test.dart
+++ b/test/regression/test_067_edit_post_refresh_test.dart
@@ -1,0 +1,183 @@
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:talker_flutter/talker_flutter.dart';
+import 'package:tsdm_client/features/settings/bloc/settings_bloc.dart';
+import 'package:tsdm_client/features/settings/repositories/settings_repository.dart';
+import 'package:tsdm_client/features/thread/v1/bloc/thread_bloc.dart';
+import 'package:tsdm_client/features/thread/v1/repository/thread_repository.dart';
+import 'package:tsdm_client/i18n/strings.g.dart';
+import 'package:tsdm_client/instance.dart';
+import 'package:tsdm_client/routes/screen_paths.dart';
+import 'package:tsdm_client/shared/models/models.dart';
+import 'package:tsdm_client/shared/providers/cookie_provider/cookie_provider.dart';
+import 'package:tsdm_client/shared/providers/image_cache_provider/image_cache_provider.dart';
+import 'package:tsdm_client/shared/providers/net_client_provider/net_client_provider.dart';
+import 'package:tsdm_client/shared/providers/net_client_provider/net_error_saver.dart';
+import 'package:tsdm_client/shared/providers/providers.dart';
+import 'package:tsdm_client/shared/providers/storage_provider/models/database/database.dart';
+import 'package:tsdm_client/shared/providers/storage_provider/storage_provider.dart';
+import 'package:tsdm_client/shared/repositories/fragments_repository/fragments_repository.dart';
+import 'package:tsdm_client/widgets/card/post_card/post_card.dart';
+
+class _RecordingThreadBloc extends ThreadBloc {
+  _RecordingThreadBloc()
+    : super(
+        tid: '42',
+        pid: null,
+        onlyVisibleUid: null,
+        reverseOrder: false,
+        exactOrder: null,
+        threadRepository: ThreadRepository(),
+      );
+
+  final events = <ThreadEvent>[];
+
+  @override
+  void add(ThreadEvent event) => events.add(event);
+}
+
+final class _OfflineAdapter implements HttpClientAdapter {
+  @override
+  Future<ResponseBody> fetch(RequestOptions options, Stream<Uint8List>? requestStream, Future<void>? cancelFuture) =>
+      throw DioException.connectionError(requestOptions: options, reason: 'offline');
+
+  @override
+  void close({bool force = false}) {}
+}
+
+void main() {
+  late AppDatabase db;
+  late SettingsRepository settings;
+  late SettingsBloc settingsBloc;
+  late _RecordingThreadBloc threadBloc;
+
+  setUpAll(() => talker = TalkerFlutter.init(settings: TalkerSettings(enabled: false)));
+  setUp(() async {
+    db = AppDatabase(NativeDatabase.memory());
+    final storage = StorageProvider(db, {}, {});
+    settings = SettingsRepository(storage);
+    getIt
+      ..registerSingleton<StorageProvider>(storage)
+      ..registerSingleton<SettingsRepository>(settings)
+      ..registerSingleton<CookieProvider>(CookieProvider.buildEmpty())
+      ..registerFactory<CookieProvider>(CookieProvider.buildEmpty, instanceName: ServiceKeys.empty)
+      ..registerSingleton<NetErrorSaver>(NetErrorSaver())
+      ..registerSingleton<ImageCacheProvider>(
+        ImageCacheProvider(NetClientProvider.buildNoCookie(dio: Dio()..httpClientAdapter = _OfflineAdapter())),
+      );
+    await settings.init();
+    settingsBloc = SettingsBloc(settingsRepository: settings, fragmentsRepository: FragmentsRepository());
+    threadBloc = _RecordingThreadBloc();
+  });
+  tearDown(() async {
+    await settingsBloc.close();
+    await threadBloc.close();
+    await getIt.reset();
+    await settings.dispose();
+    await db.close();
+  });
+
+  Future<GoRouter> openEditor(WidgetTester tester, {VoidCallback? onEdited, ValueNotifier<bool>? visible}) async {
+    final post = Post(
+      postID: '77',
+      postFloor: 41,
+      author: const User(name: 'author', url: 'u'),
+      publishTime: DateTime(2026, 9, 9),
+      data: '<p>old content</p>',
+      replyAction: null,
+      rateAction: null,
+      lastEditUsername: null,
+      lastEditTime: null,
+      shareLink: null,
+      page: 3,
+      isDraft: false,
+      packetAllTaken: false,
+      editUrl: 'forum.php?mod=post&action=edit&fid=1&tid=42&pid=77',
+    );
+    final router = GoRouter(
+      routes: [
+        GoRoute(
+          path: '/',
+          builder: (_, _) => Scaffold(
+            body: visible == null
+                ? PostCard(post, onEdited: onEdited)
+                : ValueListenableBuilder<bool>(
+                    valueListenable: visible,
+                    builder: (_, show, _) => show ? PostCard(post, onEdited: onEdited) : const SizedBox.shrink(),
+                  ),
+          ),
+        ),
+        GoRoute(
+          path: '/edit/:editType/:fid',
+          name: ScreenPaths.editPost,
+          builder: (context, _) => Scaffold(
+            body: Column(
+              children: [
+                TextButton(onPressed: () => context.pop(true), child: const Text('save succeeded')),
+                TextButton(onPressed: () => context.pop(), child: const Text('cancel edit')),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+    addTearDown(router.dispose);
+    await tester.pumpWidget(
+      MultiBlocProvider(
+        providers: [
+          BlocProvider<SettingsBloc>.value(value: settingsBloc),
+          BlocProvider<ThreadBloc>.value(value: threadBloc),
+        ],
+        child: TranslationProvider(child: MaterialApp.router(routerConfig: router)),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.byIcon(Icons.more_vert));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text(t.postCard.edit));
+    await tester.pumpAndSettle();
+    expect(find.text('save succeeded'), findsOneWidget);
+    return router;
+  }
+
+  testWidgets('saving an edited floor reloads its page instead of page one', (tester) async {
+    var positioned = false;
+    await openEditor(
+      tester,
+      onEdited: () {
+        expect(threadBloc.events, isEmpty, reason: 'set the scroll target before starting the reload');
+        positioned = true;
+      },
+    );
+    await tester.tap(find.text('save succeeded'));
+    await tester.pumpAndSettle();
+    expect(threadBloc.events, hasLength(1));
+    expect(threadBloc.events.single, isA<ThreadJumpPageRequested>().having((e) => e.pageNumber, 'page', 3));
+    expect(positioned, isTrue);
+  });
+
+  testWidgets('cancelling an edit leaves the thread untouched', (tester) async {
+    await openEditor(tester, onEdited: () => fail('cancelling must not change the scroll target'));
+    await tester.tap(find.text('cancel edit'));
+    await tester.pumpAndSettle();
+    expect(threadBloc.events, isEmpty);
+  });
+
+  testWidgets('removing the thread while editing does not reload a disposed card', (tester) async {
+    final visible = ValueNotifier(true);
+    addTearDown(visible.dispose);
+    final router = await openEditor(tester, visible: visible, onEdited: () => fail('the card is no longer mounted'));
+    visible.value = false;
+    await tester.pump();
+    router.pop(true);
+    await tester.pumpAndSettle();
+    expect(threadBloc.events, isEmpty);
+    expect(tester.takeException(), isNull);
+  });
+}


### PR DESCRIPTION
修正編輯文章成功返回後仍顯示舊內容的問題。編輯頁回傳成功結果，文章卡片只在成功時重新載入被編輯樓層所在的頁碼，並沿用文章頁的樓層定位機制；取消編輯或卡片已卸載時不刷新。

Closes #31

驗證（Flutter 3.41.1，Windows）：
- 新增 3 個 widget 回歸測試：成功返回刷新原頁、取消不刷新、卡片卸載後不刷新。修正前成功返回案例失敗（預期 1 次載入，實際 0 次），修正後通過。
- 編輯返回、PostList 樓層定位、HTML 更新相關測試共 9 個通過。
- 專案嚴格靜態分析與新增測試分析通過。
- 完整套件：451 通過、1 略過、4 失敗。四項均已在原始 546d8dc 上重現：test_026 的路徑分隔符、test_029 的兩項 Windows 路徑問題、test_066 teardown 的檔案鎖定；不屬於本次變更。

尚未進行真實論壇帳號的手動驗收。建議在第 2 頁以後編輯一則回覆，確認返回後顯示新內容並停在該樓層；再驗證取消編輯不刷新。