### PR TITLE
feat(history): filter browsing history by account (#19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+- 浏览记录：新增账号筛选。页面顶部的筛选按钮可选「全部账号」或某个账号，只看该账号的浏览记录；账号来自本机记录，已从 App 移除的账号仍可选到；同名账号在菜单里以 UID 区分，选中后按钮上会带 UID；下拉刷新时保持筛选；没有记录时给出提示。(#19)
+
 ## [1.21.1] - 2026-09-09
 
 ### Fixed

--- a/doc/spec-x5-features.md
+++ b/doc/spec-x5-features.md
@@ -506,3 +506,15 @@ release 版大小：universal 60MB／arm64 30MB（debug 142MB／106MB）。
 - `LatestThreadPage` 新增可選 `title`（路由 query `title`）與空清單提示（`latestThreadPage.empty`）；`view=hot|digest|sofa` 走同一頁。
 - i18n：`homepage.guide.{more, sofa, failed, empty}`、`latestThreadPage.empty`；移除 `homepage.latestReplySection.*`。
 - 測試 test_064（解析：四模組順序／view／更多 url、30/0/30/30 列、第一列 hot 內容、缺模組容錯、空頁；repository＋cubit 用假 adapter；widget：模組卡、更多、chip、點列到 threadV1、點更多／chip 到 latestThread、失敗重試列）、test_065（`fromTBody` 解析 hot 47 列、digest 0 列 bloc 仍 success、分頁 url、repository 接受五種 view、`LatestThreadPage` 標題與空提示）。
+
+## 18. 瀏覽紀錄依帳號篩選（GitHub #19，2026-09-10）
+
+### 18.1 範圍
+- 使用者定案：加帳號篩選、保留「全部帳號」、重新整理時維持篩選。首版由 Codex 建立（PR #39），本輪接續完善，不另外拆帳號分頁。
+
+### 18.2 App 端行為
+- `ThreadVisitHistoryPage`：篩選在已載入的紀錄上做（`state.history.where(uid)`），不走 `ThreadVisitHistoryFetchByUserRequested`，所以下拉刷新／重試後選擇不變；帳號清單從紀錄本身取（`putIfAbsent(uid, username)`，最近瀏覽的帳號在前），已從 App 移除的帳號仍可選；選中的帳號在刷新後紀錄全沒了也留在清單裡（記住 `_selectedUsername`），並顯示 `emptyForAccount`。
+- 觸發器是 `ActionChip`（漏斗圖示＋目前選擇），點下去用 `GlobalKey<PopupMenuButtonState<int>>.showButtonMenu()` 開同一個 `PopupMenuButton`（漣漪維持 chip 形狀、選單可捲動）；「全部帳號」用哨兵值 `-1`（`PopupMenuItem` 值為 null 時 `onSelected` 不會被叫）。選單用 `CheckedPopupMenuItem`：名字一行＋ `UID n` 小字，選中的打勾；chip 上只在名字與其他帳號重複時才附 UID（`accountWithUid`），名字超過 220 邏輯像素省略。
+- 空狀態：沒有任何紀錄顯示 `empty`，篩選後沒有紀錄顯示 `emptyForAccount`；都放在 `ListView` 裡，下拉刷新仍可用。
+- i18n `threadVisitHistoryPage.{filterAccount, allAccounts, accountUid, accountWithUid, empty, emptyForAccount}`。
+- 測試 test_072：選單列每個帳號一次＋UID、打勾跟著選擇、同名帳號 chip 帶 UID、不同名不帶；刷新保留篩選並顯示新紀錄；選中帳號的紀錄刪光後仍選中、顯示空提示、選單仍列該帳號；完全沒有紀錄時只有「全部帳號」一項。

--- a/lib/features/thread_visit_history/view/thread_visit_history_page.dart
+++ b/lib/features/thread_visit_history/view/thread_visit_history_page.dart
@@ -21,8 +21,82 @@ class ThreadVisitHistoryPage extends StatefulWidget {
 }
 
 class _ThreadVisitHistoryPageState extends State<ThreadVisitHistoryPage> {
+  /// Menu value of "all accounts": a `null` value never reaches `onSelected`.
+  static const _allAccounts = -1;
+
+  final _menuKey = GlobalKey<PopupMenuButtonState<int>>();
+
+  /// Account the list is filtered to, `null` for all accounts (GitHub #19).
+  ///
+  /// Filtering happens on the loaded records, so a refresh keeps the choice and the accounts come from the stored
+  /// history itself: records of an account that was removed from the app stay reachable.
   int? _selectedUid;
+
+  /// Name of [_selectedUid], kept so the chip keeps its label after the last record of that account is gone.
   String _selectedUsername = '';
+
+  void _select(int? uid, Map<int, String> accounts) => setState(() {
+    _selectedUid = uid;
+    _selectedUsername = uid == null ? '' : accounts[uid] ?? _selectedUsername;
+  });
+
+  Widget _buildFilter(BuildContext context, Map<int, String> accounts) {
+    final tr = context.t.threadVisitHistoryPage;
+    final theme = Theme.of(context);
+    // Names shared by more than one account only tell them apart with the uid.
+    final seen = <String>{};
+    final duplicated = <String>{};
+    for (final name in accounts.values) {
+      if (!seen.add(name)) {
+        duplicated.add(name);
+      }
+    }
+    String labelOf(int uid, String name) =>
+        duplicated.contains(name) ? tr.accountWithUid(username: name, uid: uid) : name;
+    final label = _selectedUid == null ? tr.allAccounts : labelOf(_selectedUid!, _selectedUsername);
+
+    return Padding(
+      padding: edgeInsetsL12T4R12B4,
+      child: Align(
+        alignment: Alignment.centerLeft,
+        child: PopupMenuButton<int>(
+          key: _menuKey,
+          tooltip: tr.filterAccount,
+          initialValue: _selectedUid ?? _allAccounts,
+          onSelected: (value) => _select(value == _allAccounts ? null : value, accounts),
+          itemBuilder: (context) => [
+            CheckedPopupMenuItem(value: _allAccounts, checked: _selectedUid == null, child: Text(tr.allAccounts)),
+            for (final MapEntry(key: uid, value: name) in accounts.entries)
+              CheckedPopupMenuItem(
+                value: uid,
+                checked: uid == _selectedUid,
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(name, maxLines: 1, overflow: TextOverflow.ellipsis),
+                    Text(
+                      tr.accountUid(uid: uid),
+                      style: theme.textTheme.bodySmall?.copyWith(color: theme.colorScheme.outline),
+                    ),
+                  ],
+                ),
+              ),
+          ],
+          // The chip handles the tap and opens the menu anchored at itself, so the ripple keeps the chip shape.
+          child: ActionChip(
+            avatar: const Icon(Icons.filter_list),
+            label: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 220),
+              child: Text(label, maxLines: 1, overflow: TextOverflow.ellipsis),
+            ),
+            onPressed: () => _menuKey.currentState?.showButtonMenu(),
+          ),
+        ),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final tr = context.t.threadVisitHistoryPage;
@@ -30,11 +104,12 @@ class _ThreadVisitHistoryPageState extends State<ThreadVisitHistoryPage> {
       create: (context) => ThreadVisitHistoryBloc(context.repo())..add(const ThreadVisitHistoryFetchAllRequested()),
       child: BlocBuilder<ThreadVisitHistoryBloc, ThreadVisitHistoryState>(
         builder: (context, state) {
+          // Most recently visited account first, the same order as the records.
           final accounts = <int, String>{};
           for (final record in state.history) {
             accounts.putIfAbsent(record.uid, () => record.username);
           }
-          // Keep the selected account available if its last record was removed during refresh.
+          // Keep the selected account in the menu when its last record was removed during a refresh.
           if (_selectedUid != null) {
             accounts.putIfAbsent(_selectedUid!, () => _selectedUsername);
           }
@@ -44,7 +119,10 @@ class _ThreadVisitHistoryPageState extends State<ThreadVisitHistoryPage> {
           final body = switch (state.status) {
             ThreadVisitHistoryStatus.initial ||
             ThreadVisitHistoryStatus.loadingData => const CenteredCircularIndicator(),
-            ThreadVisitHistoryStatus.savingData || ThreadVisitHistoryStatus.success => _Body(history),
+            ThreadVisitHistoryStatus.savingData || ThreadVisitHistoryStatus.success => _Body(
+              history,
+              emptyText: _selectedUid == null ? tr.empty : tr.emptyForAccount,
+            ),
             ThreadVisitHistoryStatus.failure => buildRetryButton(
               context,
               () => context.read<ThreadVisitHistoryBloc>().add(const ThreadVisitHistoryFetchAllRequested()),
@@ -55,39 +133,7 @@ class _ThreadVisitHistoryPageState extends State<ThreadVisitHistoryPage> {
             appBar: AppBar(title: Text(tr.title), bottom: Tips(tr.localOnlyTip, sizePreferred: true)),
             body: Column(
               children: [
-                PopupMenuButton<String>(
-                  tooltip: tr.filterAccount,
-                  initialValue: _selectedUid?.toString() ?? 'all',
-                  onSelected: (value) => setState(() {
-                    _selectedUid = int.tryParse(value);
-                    _selectedUsername = accounts[_selectedUid] ?? '';
-                  }),
-                  itemBuilder: (context) => [
-                    PopupMenuItem(value: 'all', child: Text(tr.allAccounts)),
-                    for (final account in accounts.entries)
-                      PopupMenuItem(
-                        value: account.key.toString(),
-                        child: Text('${account.value} (UID: ${account.key})'),
-                      ),
-                  ],
-                  child: Padding(
-                    padding: edgeInsetsL12T12R12B12,
-                    child: Row(
-                      children: [
-                        const Icon(Icons.filter_list),
-                        sizedBoxW12H12,
-                        Expanded(
-                          child: Text(
-                            _selectedUid == null ? tr.allAccounts : '$_selectedUsername (UID: $_selectedUid)',
-                            maxLines: 1,
-                            overflow: TextOverflow.ellipsis,
-                          ),
-                        ),
-                        const Icon(Icons.arrow_drop_down),
-                      ],
-                    ),
-                  ),
-                ),
+                _buildFilter(context, accounts),
                 Expanded(
                   child: SafeArea(
                     top: false,
@@ -104,9 +150,12 @@ class _ThreadVisitHistoryPageState extends State<ThreadVisitHistoryPage> {
 }
 
 class _Body extends StatefulWidget {
-  const _Body(this.models);
+  const _Body(this.models, {required this.emptyText});
 
   final List<ThreadVisitHistoryModel> models;
+
+  /// Hint shown instead of the list when [models] is empty.
+  final String emptyText;
 
   @override
   State<_Body> createState() => _BodyState();
@@ -136,6 +185,25 @@ class _BodyState extends State<_Body> {
       header: const MaterialHeader(),
       onRefresh: () => context.read<ThreadVisitHistoryBloc>().add(const ThreadVisitHistoryFetchAllRequested()),
       childBuilder: (context, physics) {
+        if (widget.models.isEmpty) {
+          // A list so pull-to-refresh still works on the empty page.
+          return ListView(
+            physics: physics,
+            controller: _scrollController,
+            padding: edgeInsetsL12T4R12,
+            children: [
+              sizedBoxW32H32,
+              Center(
+                child: Text(
+                  widget.emptyText,
+                  style: Theme.of(
+                    context,
+                  ).textTheme.titleMedium?.copyWith(color: Theme.of(context).colorScheme.outline),
+                ),
+              ),
+            ],
+          );
+        }
         return ListView.separated(
           controller: _scrollController,
           physics: physics,

--- a/lib/features/thread_visit_history/view/thread_visit_history_page.dart
+++ b/lib/features/thread_visit_history/view/thread_visit_history_page.dart
@@ -21,6 +21,8 @@ class ThreadVisitHistoryPage extends StatefulWidget {
 }
 
 class _ThreadVisitHistoryPageState extends State<ThreadVisitHistoryPage> {
+  int? _selectedUid;
+  String _selectedUsername = '';
   @override
   Widget build(BuildContext context) {
     final tr = context.t.threadVisitHistoryPage;
@@ -28,10 +30,21 @@ class _ThreadVisitHistoryPageState extends State<ThreadVisitHistoryPage> {
       create: (context) => ThreadVisitHistoryBloc(context.repo())..add(const ThreadVisitHistoryFetchAllRequested()),
       child: BlocBuilder<ThreadVisitHistoryBloc, ThreadVisitHistoryState>(
         builder: (context, state) {
+          final accounts = <int, String>{};
+          for (final record in state.history) {
+            accounts.putIfAbsent(record.uid, () => record.username);
+          }
+          // Keep the selected account available if its last record was removed during refresh.
+          if (_selectedUid != null) {
+            accounts.putIfAbsent(_selectedUid!, () => _selectedUsername);
+          }
+          final history = _selectedUid == null
+              ? state.history
+              : state.history.where((record) => record.uid == _selectedUid).toList();
           final body = switch (state.status) {
             ThreadVisitHistoryStatus.initial ||
             ThreadVisitHistoryStatus.loadingData => const CenteredCircularIndicator(),
-            ThreadVisitHistoryStatus.savingData || ThreadVisitHistoryStatus.success => _Body(state.history),
+            ThreadVisitHistoryStatus.savingData || ThreadVisitHistoryStatus.success => _Body(history),
             ThreadVisitHistoryStatus.failure => buildRetryButton(
               context,
               () => context.read<ThreadVisitHistoryBloc>().add(const ThreadVisitHistoryFetchAllRequested()),
@@ -40,8 +53,48 @@ class _ThreadVisitHistoryPageState extends State<ThreadVisitHistoryPage> {
 
           return Scaffold(
             appBar: AppBar(title: Text(tr.title), bottom: Tips(tr.localOnlyTip, sizePreferred: true)),
-            body: SafeArea(
-              child: AnimatedSwitcher(duration: duration200, child: body),
+            body: Column(
+              children: [
+                PopupMenuButton<String>(
+                  tooltip: tr.filterAccount,
+                  initialValue: _selectedUid?.toString() ?? 'all',
+                  onSelected: (value) => setState(() {
+                    _selectedUid = int.tryParse(value);
+                    _selectedUsername = accounts[_selectedUid] ?? '';
+                  }),
+                  itemBuilder: (context) => [
+                    PopupMenuItem(value: 'all', child: Text(tr.allAccounts)),
+                    for (final account in accounts.entries)
+                      PopupMenuItem(
+                        value: account.key.toString(),
+                        child: Text('${account.value} (UID: ${account.key})'),
+                      ),
+                  ],
+                  child: Padding(
+                    padding: edgeInsetsL12T12R12B12,
+                    child: Row(
+                      children: [
+                        const Icon(Icons.filter_list),
+                        sizedBoxW12H12,
+                        Expanded(
+                          child: Text(
+                            _selectedUid == null ? tr.allAccounts : '$_selectedUsername (UID: $_selectedUid)',
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ),
+                        const Icon(Icons.arrow_drop_down),
+                      ],
+                    ),
+                  ),
+                ),
+                Expanded(
+                  child: SafeArea(
+                    top: false,
+                    child: AnimatedSwitcher(duration: duration200, child: body),
+                  ),
+                ),
+              ],
             ),
           );
         },

--- a/lib/i18n/en.i18n.json
+++ b/lib/i18n/en.i18n.json
@@ -1139,6 +1139,8 @@
     "openLink": "Open link"
   },
   "threadVisitHistoryPage": {
+    "filterAccount": "Filter by account",
+    "allAccounts": "All accounts",
     "entryTooltip": "Thread browsing history",
     "title": "Thread browsing history",
     "localOnlyTip": "Only local browsing history was recorded, may be different on web side or other machines"

--- a/lib/i18n/en.i18n.json
+++ b/lib/i18n/en.i18n.json
@@ -1141,6 +1141,10 @@
   "threadVisitHistoryPage": {
     "filterAccount": "Filter by account",
     "allAccounts": "All accounts",
+    "accountUid": "UID $uid",
+    "accountWithUid": "$username (UID $uid)",
+    "empty": "No browsing history yet",
+    "emptyForAccount": "No browsing history for this account",
     "entryTooltip": "Thread browsing history",
     "title": "Thread browsing history",
     "localOnlyTip": "Only local browsing history was recorded, may be different on web side or other machines"

--- a/lib/i18n/zh-CN.i18n.json
+++ b/lib/i18n/zh-CN.i18n.json
@@ -1139,6 +1139,8 @@
     "openLink": "打开链接"
   },
   "threadVisitHistoryPage": {
+    "filterAccount": "按账号筛选",
+    "allAccounts": "全部账号",
     "entryTooltip": "帖子浏览记录",
     "title": "帖子浏览记录",
     "localOnlyTip": "仅记录本机的浏览记录，在网页端或其他机器上可能会有所不同"

--- a/lib/i18n/zh-CN.i18n.json
+++ b/lib/i18n/zh-CN.i18n.json
@@ -1141,6 +1141,10 @@
   "threadVisitHistoryPage": {
     "filterAccount": "按账号筛选",
     "allAccounts": "全部账号",
+    "accountUid": "UID $uid",
+    "accountWithUid": "$username（UID $uid）",
+    "empty": "还没有浏览记录",
+    "emptyForAccount": "这个账号没有浏览记录",
     "entryTooltip": "帖子浏览记录",
     "title": "帖子浏览记录",
     "localOnlyTip": "仅记录本机的浏览记录，在网页端或其他机器上可能会有所不同"

--- a/lib/i18n/zh-TW.i18n.json
+++ b/lib/i18n/zh-TW.i18n.json
@@ -1141,6 +1141,10 @@
   "threadVisitHistoryPage": {
     "filterAccount": "依帳號篩選",
     "allAccounts": "全部帳號",
+    "accountUid": "UID $uid",
+    "accountWithUid": "$username（UID $uid）",
+    "empty": "還沒有瀏覽紀錄",
+    "emptyForAccount": "這個帳號沒有瀏覽紀錄",
     "entryTooltip": "貼文瀏覽紀錄",
     "title": "貼文瀏覽紀錄",
     "localOnlyTip": "僅記錄本機的瀏覽記錄，在網頁端或其他機器上可能會有所不同"

--- a/lib/i18n/zh-TW.i18n.json
+++ b/lib/i18n/zh-TW.i18n.json
@@ -1139,6 +1139,8 @@
     "openLink": "開啟連結"
   },
   "threadVisitHistoryPage": {
+    "filterAccount": "依帳號篩選",
+    "allAccounts": "全部帳號",
     "entryTooltip": "貼文瀏覽紀錄",
     "title": "貼文瀏覽紀錄",
     "localOnlyTip": "僅記錄本機的瀏覽記錄，在網頁端或其他機器上可能會有所不同"

--- a/test/regression/test_072_history_account_filter_test.dart
+++ b/test/regression/test_072_history_account_filter_test.dart
@@ -1,0 +1,86 @@
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:talker_flutter/talker_flutter.dart';
+import 'package:tsdm_client/features/thread_visit_history/bloc/thread_visit_history_bloc.dart';
+import 'package:tsdm_client/features/thread_visit_history/repository/thread_visit_history_repository.dart';
+import 'package:tsdm_client/features/thread_visit_history/view/thread_visit_history_page.dart';
+import 'package:tsdm_client/features/thread_visit_history/widgets/thread_visit_history_card.dart';
+import 'package:tsdm_client/i18n/strings.g.dart';
+import 'package:tsdm_client/instance.dart';
+import 'package:tsdm_client/shared/providers/storage_provider/models/database/database.dart';
+import 'package:tsdm_client/shared/providers/storage_provider/storage_provider.dart';
+
+void main() {
+  late AppDatabase db;
+  late StorageProvider storage;
+  setUpAll(() => talker = TalkerFlutter.init(settings: TalkerSettings(enabled: false)));
+  setUp(() {
+    db = AppDatabase(NativeDatabase.memory());
+    storage = StorageProvider(db, {}, {});
+  });
+  tearDown(() async => db.close());
+
+  Future<void> save(int uid, int tid, String title) async {
+    await storage.updateThreadVisitHistory(
+      uid: uid,
+      tid: tid,
+      fid: 1,
+      username: 'Same name',
+      threadTitle: title,
+      forumName: 'Forum',
+      visitTime: DateTime(2026, 9, 10),
+    );
+  }
+
+  Future<void> pump(WidgetTester tester) async {
+    await tester.runAsync(() async {
+      await save(11, 100, 'Account A thread');
+      await save(22, 100, 'Account B thread');
+    });
+    await tester.pumpWidget(
+      RepositoryProvider.value(
+        value: ThreadVisitHistoryRepo(storage),
+        child: TranslationProvider(child: const MaterialApp(home: ThreadVisitHistoryPage())),
+      ),
+    );
+    await tester.runAsync(() => Future<void>.delayed(const Duration(milliseconds: 100)));
+    await tester.pumpAndSettle();
+  }
+
+  List<int> visibleAccounts(WidgetTester tester) =>
+      tester.widgetList<ThreadVisitHistoryCard>(find.byType(ThreadVisitHistoryCard)).map((c) => c.model.uid).toList();
+
+  Future<void> select(WidgetTester tester, String label) async {
+    await tester.tap(find.byIcon(Icons.filter_list));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text(label).last);
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('history filter distinguishes accounts with the same name and restores all accounts', (tester) async {
+    await pump(tester);
+    expect(visibleAccounts(tester), containsAll([11, 22]));
+    await select(tester, 'Same name (UID: 11)');
+    expect(visibleAccounts(tester), [11]);
+    await select(tester, 'Same name (UID: 22)');
+    expect(visibleAccounts(tester), [22]);
+    await select(tester, 'All accounts');
+    expect(visibleAccounts(tester), containsAll([11, 22]));
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('refresh retains account filter while loading new records', (tester) async {
+    await pump(tester);
+    await select(tester, 'Same name (UID: 11)');
+    await tester.runAsync(() => save(11, 101, 'New A thread'));
+    final bloc = tester.element(find.byType(ThreadVisitHistoryCard).first).read<ThreadVisitHistoryBloc>();
+    bloc.add(const ThreadVisitHistoryFetchAllRequested());
+    await tester.pump();
+    await tester.runAsync(() => Future<void>.delayed(const Duration(milliseconds: 100)));
+    await tester.pumpAndSettle();
+    expect(visibleAccounts(tester), [11, 11]);
+    expect(find.text('New A thread'), findsOneWidget);
+  });
+}

--- a/test/regression/test_072_history_account_filter_test.dart
+++ b/test/regression/test_072_history_account_filter_test.dart
@@ -66,13 +66,16 @@ void main() {
     await tester.pumpAndSettle();
   }
 
+  Finder inMenu(String text) => find.descendant(of: find.byType(CheckedPopupMenuItem<int>), matching: find.text(text));
+
+  /// The whole menu item holding [text]: the item's list tile ignores pointers, so tapping the text would only warn.
+  Finder menuItem(String text) => find.ancestor(of: inMenu(text), matching: find.byType(CheckedPopupMenuItem<int>));
+
   Future<void> select(WidgetTester tester, String label) async {
     await openMenu(tester);
-    await tester.tap(find.text(label).last);
+    await tester.tap(menuItem(label));
     await tester.pumpAndSettle();
   }
-
-  Finder inMenu(String text) => find.descendant(of: find.byType(CheckedPopupMenuItem<int>), matching: find.text(text));
 
   Finder onChip(String text) => find.descendant(of: find.byType(ActionChip), matching: find.text(text));
 
@@ -95,14 +98,14 @@ void main() {
     expect(inMenu('Same name'), findsNWidgets(2));
     expect(inMenu('Other name'), findsOneWidget);
     expect(checkedValues(tester), [-1]);
-    await tester.tap(inMenu('UID 11'));
+    await tester.tap(menuItem('UID 11'));
     await tester.pumpAndSettle();
     expect(visibleAccounts(tester), [11]);
     // Same name as account 22: the chip carries the uid so the choice is unambiguous.
     expect(onChip('Same name (UID 11)'), findsOneWidget);
     await openMenu(tester);
     expect(checkedValues(tester), [11]);
-    await tester.tap(inMenu('Other name'));
+    await tester.tap(menuItem('Other name'));
     await tester.pumpAndSettle();
     expect(visibleAccounts(tester), [33]);
     // A unique name needs no uid on the chip.
@@ -143,7 +146,7 @@ void main() {
     // The account is still offered in the menu so the user can see what is filtered.
     await openMenu(tester);
     expect(inMenu('UID 33'), findsOneWidget);
-    await tester.tap(inMenu('All accounts'));
+    await tester.tap(menuItem('All accounts'));
     await tester.pumpAndSettle();
     expect(visibleAccounts(tester), [22, 11]);
   });

--- a/test/regression/test_072_history_account_filter_test.dart
+++ b/test/regression/test_072_history_account_filter_test.dart
@@ -12,6 +12,8 @@ import 'package:tsdm_client/instance.dart';
 import 'package:tsdm_client/shared/providers/storage_provider/models/database/database.dart';
 import 'package:tsdm_client/shared/providers/storage_provider/storage_provider.dart';
 
+/// GitHub #19: the browsing history page filters the records by account, "All accounts" stays available, the choice
+/// survives a refresh and accounts with the same name are told apart by uid.
 void main() {
   late AppDatabase db;
   late StorageProvider storage;
@@ -22,65 +24,134 @@ void main() {
   });
   tearDown(() async => db.close());
 
-  Future<void> save(int uid, int tid, String title) async {
+  Future<void> save(int uid, int tid, String title, {String username = 'Same name', DateTime? visitTime}) async {
     await storage.updateThreadVisitHistory(
       uid: uid,
       tid: tid,
       fid: 1,
-      username: 'Same name',
+      username: username,
       threadTitle: title,
       forumName: 'Forum',
-      visitTime: DateTime(2026, 9, 10),
+      visitTime: visitTime ?? DateTime(2026, 9, 10),
     );
   }
 
-  Future<void> pump(WidgetTester tester) async {
-    await tester.runAsync(() async {
-      await save(11, 100, 'Account A thread');
-      await save(22, 100, 'Account B thread');
-    });
+  Future<void> settle(WidgetTester tester) async {
+    await tester.runAsync(() => Future<void>.delayed(const Duration(milliseconds: 100)));
+    await tester.pumpAndSettle();
+  }
+
+  Future<void> pump(WidgetTester tester, {bool seed = true}) async {
+    if (seed) {
+      await tester.runAsync(() async {
+        await save(11, 100, 'Account A thread', visitTime: DateTime(2026, 9, 10, 8));
+        await save(22, 100, 'Account B thread', visitTime: DateTime(2026, 9, 10, 9));
+        await save(33, 101, 'Account C thread', username: 'Other name', visitTime: DateTime(2026, 9, 10, 7));
+      });
+    }
     await tester.pumpWidget(
       RepositoryProvider.value(
         value: ThreadVisitHistoryRepo(storage),
         child: TranslationProvider(child: const MaterialApp(home: ThreadVisitHistoryPage())),
       ),
     );
-    await tester.runAsync(() => Future<void>.delayed(const Duration(milliseconds: 100)));
-    await tester.pumpAndSettle();
+    await settle(tester);
   }
 
   List<int> visibleAccounts(WidgetTester tester) =>
       tester.widgetList<ThreadVisitHistoryCard>(find.byType(ThreadVisitHistoryCard)).map((c) => c.model.uid).toList();
 
-  Future<void> select(WidgetTester tester, String label) async {
-    await tester.tap(find.byIcon(Icons.filter_list));
+  Future<void> openMenu(WidgetTester tester) async {
+    await tester.tap(find.byType(ActionChip));
     await tester.pumpAndSettle();
+  }
+
+  Future<void> select(WidgetTester tester, String label) async {
+    await openMenu(tester);
     await tester.tap(find.text(label).last);
     await tester.pumpAndSettle();
   }
 
-  testWidgets('history filter distinguishes accounts with the same name and restores all accounts', (tester) async {
+  Finder inMenu(String text) => find.descendant(of: find.byType(CheckedPopupMenuItem<int>), matching: find.text(text));
+
+  Finder onChip(String text) => find.descendant(of: find.byType(ActionChip), matching: find.text(text));
+
+  List<int> checkedValues(WidgetTester tester) => tester
+      .widgetList<CheckedPopupMenuItem<int>>(find.byType(CheckedPopupMenuItem<int>))
+      .where((e) => e.checked)
+      .map((e) => e.value!)
+      .toList();
+
+  testWidgets('the menu lists every account once with its uid, checked item follows the choice', (tester) async {
     await pump(tester);
-    expect(visibleAccounts(tester), containsAll([11, 22]));
-    await select(tester, 'Same name (UID: 11)');
+    expect(visibleAccounts(tester), [22, 11, 33]);
+    // The chip shows "all accounts" and no uid until a name collides in the choice.
+    expect(onChip('All accounts'), findsOneWidget);
+    await openMenu(tester);
+    expect(find.byType(CheckedPopupMenuItem<int>), findsNWidgets(4));
+    expect(inMenu('UID 11'), findsOneWidget);
+    expect(inMenu('UID 22'), findsOneWidget);
+    expect(inMenu('UID 33'), findsOneWidget);
+    expect(inMenu('Same name'), findsNWidgets(2));
+    expect(inMenu('Other name'), findsOneWidget);
+    expect(checkedValues(tester), [-1]);
+    await tester.tap(inMenu('UID 11'));
+    await tester.pumpAndSettle();
     expect(visibleAccounts(tester), [11]);
-    await select(tester, 'Same name (UID: 22)');
-    expect(visibleAccounts(tester), [22]);
+    // Same name as account 22: the chip carries the uid so the choice is unambiguous.
+    expect(onChip('Same name (UID 11)'), findsOneWidget);
+    await openMenu(tester);
+    expect(checkedValues(tester), [11]);
+    await tester.tap(inMenu('Other name'));
+    await tester.pumpAndSettle();
+    expect(visibleAccounts(tester), [33]);
+    // A unique name needs no uid on the chip.
+    expect(onChip('Other name'), findsOneWidget);
     await select(tester, 'All accounts');
-    expect(visibleAccounts(tester), containsAll([11, 22]));
+    expect(visibleAccounts(tester), [22, 11, 33]);
     expect(tester.takeException(), isNull);
   });
 
-  testWidgets('refresh retains account filter while loading new records', (tester) async {
+  testWidgets('refresh keeps the account filter and shows new records of that account', (tester) async {
     await pump(tester);
-    await select(tester, 'Same name (UID: 11)');
-    await tester.runAsync(() => save(11, 101, 'New A thread'));
-    final bloc = tester.element(find.byType(ThreadVisitHistoryCard).first).read<ThreadVisitHistoryBloc>();
-    bloc.add(const ThreadVisitHistoryFetchAllRequested());
+    await select(tester, 'UID 11');
+    await tester.runAsync(() => save(11, 101, 'New A thread', visitTime: DateTime(2026, 9, 10, 10)));
+    tester
+        .element(find.byType(ThreadVisitHistoryCard).first)
+        .read<ThreadVisitHistoryBloc>()
+        .add(const ThreadVisitHistoryFetchAllRequested());
     await tester.pump();
-    await tester.runAsync(() => Future<void>.delayed(const Duration(milliseconds: 100)));
-    await tester.pumpAndSettle();
+    await settle(tester);
     expect(visibleAccounts(tester), [11, 11]);
     expect(find.text('New A thread'), findsOneWidget);
+    expect(onChip('Same name (UID 11)'), findsOneWidget);
+  });
+
+  testWidgets('an account whose records are gone stays selected and shows the empty hint', (tester) async {
+    await pump(tester);
+    await select(tester, 'Other name');
+    expect(visibleAccounts(tester), [33]);
+    tester
+        .element(find.byType(ThreadVisitHistoryCard).first)
+        .read<ThreadVisitHistoryBloc>()
+        .add(const ThreadVisitHistoryDeleteRecordRequested(uid: 33, tid: 101));
+    await tester.pump();
+    await settle(tester);
+    expect(find.byType(ThreadVisitHistoryCard), findsNothing);
+    expect(find.text('No browsing history for this account'), findsOneWidget);
+    expect(onChip('Other name'), findsOneWidget);
+    // The account is still offered in the menu so the user can see what is filtered.
+    await openMenu(tester);
+    expect(inMenu('UID 33'), findsOneWidget);
+    await tester.tap(inMenu('All accounts'));
+    await tester.pumpAndSettle();
+    expect(visibleAccounts(tester), [22, 11]);
+  });
+
+  testWidgets('no records at all: the empty hint and only the "all accounts" entry', (tester) async {
+    await pump(tester, seed: false);
+    expect(find.text('No browsing history yet'), findsOneWidget);
+    await openMenu(tester);
+    expect(find.byType(CheckedPopupMenuItem<int>), findsOneWidget);
   });
 }


### PR DESCRIPTION
處理 #19：瀏覽紀錄加入帳號篩選，保留「全部帳號」，重新整理時維持篩選。首版由 Codex 建立，本輪接續檢查與完善。

## 修改內容

- 篩選改成 chip 樣式的觸發器（漏斗圖示＋目前的選擇），點下去開同一個 `PopupMenuButton` 的選單（可捲動，帳號多也不會被截掉）。選單用 `CheckedPopupMenuItem`：每個帳號一行名字＋ `UID n` 小字，目前選中的打勾；「全部帳號」用哨兵值 `-1`（`PopupMenuItem` 的值為 null 時不會觸發 `onSelected`）。
- chip 上只在名字與其他帳號重複時才附 UID（`accountWithUid`），名字過長省略；帳號順序＝最近瀏覽的在前，與紀錄順序一致。
- 篩選仍在已載入的紀錄上做，所以下拉刷新／重試後選擇不變；帳號來自紀錄本身，已從 App 移除的帳號仍可選；選中的帳號在刷新後紀錄全沒了也留在清單裡並顯示提示。
- 空狀態：完全沒有紀錄顯示「還沒有瀏覽紀錄」，篩選後沒有紀錄顯示「這個帳號沒有瀏覽紀錄」；都放在 `ListView` 裡，下拉刷新仍可用。
- i18n 三語新增 `accountUid`、`accountWithUid`、`empty`、`emptyForAccount`（英／簡／繁 key 對齊，共 1038 個）。
- CHANGELOG `Unreleased` 加 #19 條目；`doc/spec-x5-features.md` 新增 §18。

## 測試結果

- `test/regression/test_072_history_account_filter_test.dart` 改寫為四個案例：選單列每個帳號一次＋UID、打勾跟著選擇、同名帳號 chip 帶 UID、不同名不帶；刷新保留篩選並顯示該帳號的新紀錄；選中帳號的紀錄刪光後仍選中、顯示空提示、選單仍列該帳號；完全沒有紀錄時只有「全部帳號」一項。
- 離線渲染（360×780、淺色／深色、含同名帳號與超長名字）看過：chip、選單、篩選後的列表都正常。
- 本機 `flutter test` 全套 466 passed、1 skipped；`dart analyze` 只剩 master 既有的 `Makefile.dart` 與 `test_071` 的 info。

## 尚未驗證

- Android 實機：實際操作（選帳號、切回全部、篩選中下拉刷新、11 個帳號的選單捲動）。已請回報者用測試包確認（見下方留言）。
- 與 #40 都改了 CHANGELOG 的 `Unreleased` 段落，後合併的那個需要處理一次小衝突。

## 測試包

- [Android 測試建置 run 34390833111](https://github.com/Carinoasd/tsdm_client/actions/runs/34390833111)（commit `7b3c3e89`，之後的 `f6876980` 只改測試）→ artifact [`tsdm_client-apk-arm64_v8a`](https://github.com/Carinoasd/tsdm_client/actions/runs/34390833111/artifacts/10120313783)，內含 arm64 與 armv7 兩個 apk。已下載驗證：簽章 SHA-256 `71f7ca2c…8f23`（正式金鑰）、package `com.tsdm.tsdm_client`、versionCode 713／712（與 1.21.1 相同，可覆蓋安裝）。
- 已在 #19 留言請回報者測試。
