### PR TITLE
fix(android): one-variable comparison build for the rotation transition — Skia instead of Impeller (#28)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
+- Android：绘图改用 Skia（manifest 关闭 Impeller）。鸿蒙 4.2 手机上旋转过场会短暂露出黑色，同一手机上用 Skia 绘图的 Flutter 应用没有这个现象；这是只改这一个变量的对照修改，其余设置不变，待回报者在同一手机确认后再决定是否保留或改用 Impeller 的 OpenGL ES 后端。(#28)
 - 诊断：为「视窗尺寸变化后画面仍沿用旧尺寸」的问题加入尺寸日志（Android）。系统送来的配置变化、多窗口／小窗切换、Flutter 视图的布局尺寸与绘图表面尺寸，以及 Flutter 端实际排版用的尺寸、键盘高度与其后一帧，都会写进「设置 → 除错 → 日志」，用来判断是哪一层没有跟着改变。只记录日志，不改变排版。(#28)
 
 ### Added

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -36,5 +36,11 @@
         <meta-data
                 android:name="flutterEmbedding"
                 android:value="2"/>
+        <!-- GitHub #28: the rotation transition on a HarmonyOS 4.2 phone shows black while the app is drawing
+             through Impeller; the Flutter app the reporter compared with (Kazumi) draws through Skia. This is the
+             single variable of the comparison build: everything else stays as it is. -->
+        <meta-data
+                android:name="io.flutter.embedding.android.EnableImpeller"
+                android:value="false"/>
     </application>
 </manifest>

--- a/doc/spec-x5-features.md
+++ b/doc/spec-x5-features.md
@@ -631,3 +631,27 @@ release 版大小：universal 60MB／arm64 30MB（debug 142MB／106MB）。
 - 模擬器（AOSP 14，docker，arm64 轉譯）：3.41.1 建的 debug 包跑 8 輪「旋轉→小窗→縮小→放大」失敗 2 輪；換 3.41.5 重建後同樣迴圈 8 輪全部正常，verbose 嵌入層日誌裡沒有再出現 `Resize was in response to the engine resizing the view`（3.41.1 那輪 8 個日誌有 4 個出現、共 9 次）。
 - 實機：回報者裝 3.41.5 建的測試包重做平板的小窗／全螢幕／回覆與手機的橫豎切換；若仍出現，匯出日誌依 §21.4 判法看是哪一層。
 
+### 21.6 第二輪：手機旋轉過場露黑（2026-09-10 下午）
+
+**回報**：PR #51（Flutter 3.41.5）之後，鴻蒙 2 平板沒再出現；鴻蒙 4.2 手機旋轉**完成後**排版正確，但**過場**異常，豎轉橫最明顯；同一支手機上另一個 Flutter App（Kazumi）的旋轉沒有問題。
+附新影片（外拍，60 fps）與日誌 `log_1789017760605.txt`。
+
+**日誌**：四次旋轉都是 `configurationChanged` → 新尺寸的 `view metrics`（+25～40 ms）→ `surfaceChanged`／`flutterViewLayout` → `frame painted`（+35～55 ms），沒有再出現尺寸被吞掉；
+`frame painted` 只代表 framework 出了一幀，不代表畫面已經顯示。
+
+**影片逐格**（30 fps 取樣）：顯示方向切換後，系統的旋轉動畫把舊畫面截圖轉過去，截圖底下露出的是**黑色**（約 4～5 格，130～170 ms），之後才換成新方向的排版。
+黑色不是視窗背景（`NormalTheme` 的 `windowBackground` 是 `?android:colorBackground`，淺色主題下是白的），而是 SurfaceView 的黑色背景層——新尺寸的第一個 buffer 還沒送出時露出來的東西。
+
+**目前的繪圖設定**（master）：Impeller 預設開啟、後端由引擎依裝置選（Vulkan，不支援時 GLES）；`FlutterActivity` 預設 opaque → SurfaceView 繪圖；
+`hardwareAccelerated=true`；`configChanges` 含 orientation／screenSize（不重建 Activity）；`NormalTheme` 淺色背景；core-splashscreen。manifest 沒有任何 Impeller／content sizing 旗標。
+
+**對照 App（Kazumi，`Predidit/Kazumi` main）**：manifest 明確 `io.flutter.embedding.android.EnableImpeller=false`（Skia），其餘（theme、configChanges、adjustResize、hardwareAccelerated、SurfaceView）與本 App 相同；Flutter 3.47.2。
+兩個 App 在同一支手機上的差異裡，與旋轉過場有關的只有繪圖後端。
+
+**對照包（PR #52，只改一個變因）**：manifest 加 `EnableImpeller=false`，其他完全不動（Flutter 3.41.5 仍支援這個 opt-out：`FlutterLoader` 會加 `--enable-impeller=false`，Android shell 仍有 `android_surface_gl_skia`）。
+模擬器確認：logcat 出現引擎的 opt-out 訊息、旋轉／freeform 縮放正常。請回報者在同一支鴻蒙 4.2 手機、同一個頁面、同樣的豎轉橫做對照。
+
+**判讀**：
+- 過場乾淨 → 變因是繪圖後端。下一步再做第二個單變因包 `ImpellerBackend=opengles`（保留 Impeller 只換 GPU API）決定正式修法：GLES 也乾淨就用 GLES，否則先用 Skia（Kazumi 的做法；Skia 在 Android 上是即將移除的 opt-out，之後要跟著 Flutter 版本重新評估）。
+- 仍露黑 → 與繪圖後端無關，下一個單變因是 SurfaceView → TextureView（`getRenderMode`），再不行就是系統的旋轉動畫本身（同機其他非 Flutter App 對照）。
+


### PR DESCRIPTION
## 問題

GitHub #28 第二輪：PR #51（Flutter 3.41.5）之後鴻蒙 2 平板沒再出現舊尺寸；鴻蒙 4.2 手機旋轉**完成後**排版正確，但**過場**異常（豎轉橫最明顯），同一支手機上的另一個 Flutter App（Kazumi）沒有這個現象。新影片與日誌在議題裡。

## 目前的繪圖設定（master）

Impeller 預設開啟、後端由引擎選（Vulkan，不支援時 GLES）；`FlutterActivity` 預設 opaque → SurfaceView；`hardwareAccelerated=true`；`configChanges` 含 orientation／screenSize；`NormalTheme` 淺色 `windowBackground`；manifest 沒有任何 Impeller 相關旗標。

## 判讀

- 日誌：四次旋轉都是 `configurationChanged` → 新尺寸的 `view metrics`（+25～40 ms）→ `surfaceChanged`／`flutterViewLayout` → `frame painted`（+35～55 ms），沒有尺寸被吞掉；`frame painted` 只代表 framework 出了一幀，不代表畫面已顯示。
- 影片逐格（30 fps）：系統旋轉動畫把舊畫面截圖轉過去時，截圖底下露出**黑色**約 4～5 格（130～170 ms），之後才換成新排版。黑色不是視窗背景（淺色主題是白的），是 SurfaceView 的黑色背景層——新尺寸的第一個 buffer 還沒送出時露出來的。
- 對照 App Kazumi（`Predidit/Kazumi`）：manifest 明確 `EnableImpeller=false`（Skia），其餘 Android 設定（theme、configChanges、adjustResize、hardwareAccelerated、SurfaceView）與本 App 相同。兩個 App 在同一支手機的差異裡，與旋轉過場有關的只有繪圖後端。

## 修改內容（只改一個變因）

- `AndroidManifest.xml`：加 `io.flutter.embedding.android.EnableImpeller=false`，其他完全不動。Flutter 3.41.5 仍支援這個 opt-out（`FlutterLoader` 加 `--enable-impeller=false`、Android shell 仍有 Skia GL surface）。
- `CHANGELOG.md` Unreleased（Changed）、`doc/spec-x5-features.md` §21.6（含判讀與後續決策）。

這是**對照實驗兼候選修法**：請回報者在同一支鴻蒙 4.2 手機、同一頁面、同樣的豎轉橫做對照。過場乾淨 → 變因確定是繪圖後端，再做第二個單變因包 `ImpellerBackend=opengles` 決定正式修法（GLES 乾淨就用 GLES，否則先用 Skia，並隨 Flutter 版本重新評估，因為 Skia 在 Android 上是即將移除的 opt-out）；仍露黑 → 這個 PR 不合併，下一個單變因是 SurfaceView → TextureView。

## 測試結果

- 模擬器（AOSP 14，arm64 轉譯，debug 包）：logcat 出現引擎的「[Action Required]: Impeller opt-out deprecated」訊息（旗標生效、改走 Skia）；旋轉與 freeform 小窗↔全螢幕各 2 次排版正確、metrics 都到，沒有 `Resize was in response` 行。模擬器本來就沒有露黑的現象，只能確認旗標生效與沒有退化。
- `flutter test`：483 passed / 1 skipped（3.41.5，與 master 相同；本 PR 沒動 Dart）
- `dart analyze`：只剩既有的 info；`dart format` 無差異。

## 尚未驗證／限制

- 沒有那支手機；模擬器沒有露黑的現象，只能確認旗標生效與功能沒有退化。
- 用 Skia 會少掉 Impeller 的效果（例如 1.11.0 那個「重定向圖示在 Impeller 下壞掉」的 workaround 就不再需要），也失去 Impeller 的效能特性；這些等回報者結果再權衡。
- CHANGELOG 的 Unreleased 段與其他 PR 可能有小衝突。

## 測試包

- CI「Test build」run 34443819478（commit 665c8287，Flutter 3.41.5）：[tsdm_client-apk-arm64_v8a](https://github.com/Carinoasd/tsdm_client/actions/runs/34443819478/artifacts/10139343144)（zip 內含 arm64 與 armv7 兩個 APK；下載需登入 GitHub）。
- 已驗證：官方金鑰（憑證 SHA-256 `71f7ca2c…8f23`）、package `com.tsdm.tsdm_client`、versionCode 713／712、APK 內的 manifest 含 `EnableImpeller=false`；可直接覆蓋安裝在 1.21.1 上。以 master 467f3cda 為基底（含 #49／#50／#51）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

